### PR TITLE
Do not try to truncate views

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -31,7 +31,7 @@ module DatabaseCleaner
       end
 
       def database_tables
-        ::ActiveRecord::VERSION::MAJOR >= 5 ? data_sources : tables
+        tables
       end
 
       def truncate_table(table_name)
@@ -143,6 +143,10 @@ module DatabaseCleaner
 
       def restart_identity
         @restart_identity ||= db_version >=  80400 ? 'RESTART IDENTITY' : ''
+      end
+
+      def database_tables
+        tables_with_schema
       end
 
       def truncate_table(table_name)

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
       end
 
       describe '#clean' do
+        before do
+          # Clean should not try to truncate database views. If it does, it will raise an error
+          connection.execute "CREATE VIEW view1 AS SELECT * FROM schema_migrations;"
+        end
+
+        after do
+          connection.execute "DROP VIEW view1"
+        end
+
         context "with records" do
           before do
             2.times { User.create! }


### PR DESCRIPTION
We should always call `tables` because it will only return tables and not views
since Rails 5.
Also, for the sake of consistency the PostgreSQLAdapter should use the same table
lookup logic for both the cached and non-cached variant.