### PR TITLE
Add SQLServerAdapter with view_cache override method

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -205,6 +205,14 @@ module DatabaseCleaner
         rows.collect { |result| result.first }
       end
     end
+
+    module SQLServerAdapter
+      include TruncateOrDelete
+
+      def database_cleaner_view_cache
+        @views ||= select_values("select table_name from information_schema.views") rescue []
+      end
+    end
   end
 end
 
@@ -227,7 +235,7 @@ module ActiveRecord
     SQLite3Adapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::SQLiteAdapter } if defined?(SQLite3Adapter)
     PostgreSQLAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::PostgreSQLAdapter } if defined?(PostgreSQLAdapter)
     IBM_DBAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::IBM_DBAdapter } if defined?(IBM_DBAdapter)
-    SQLServerAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::TruncateOrDelete } if defined?(SQLServerAdapter)
+    SQLServerAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::SQLServerAdapter } if defined?(SQLServerAdapter)
     OracleEnhancedAdapter.class_eval { include ::DatabaseCleaner::ConnectionAdapters::OracleAdapter } if defined?(OracleEnhancedAdapter)
   end
 end


### PR DESCRIPTION
Copied from https://github.com/DatabaseCleaner/database_cleaner/pull/578

I created a SQLServerAdapter to so I could override the implementation of the database_cleaner_view_cache method since sql server.

The other option was to change the underlying implementation of https://github.com/DatabaseCleaner/database_cleaner/blame/master/lib/database_cleaner/active_record/truncation.rb#L25 
I'm not sure why this is part of the base implementation?
```ruby
 where table_schema = '#{current_database}'
```