### PR TITLE
[BREAKING CHANGE] Remove non-functional { reset_ids: false } truncation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ If you are using ActiveRecord then take a look at the [additional options](#addi
 The following options are available for ActiveRecord's `:truncation` strategy _only_ for MySQL and Postgres.
 
 * `:pre_count` - When set to `true` this will check each table for existing rows before truncating it.  This can speed up test suites when many of the tables to be truncated are never populated. Defaults to `:false`. (Also, see the section on [What strategy is fastest?](#what-strategy-is-fastest))
-* `:reset_ids` - This only matters when `:pre_count` is used, and it will make sure that a tables auto-incrementing id is reset even if there are no rows in the table (e.g. records were created in the test but also removed before DatabaseCleaner gets to it). Defaults to `true`.
 
 The following option is available for ActiveRecord's `:truncation` and `:deletion` strategy for any DB.
 

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -54,9 +54,8 @@ module DatabaseCleaner
           tables.each { |t| truncate_table(t) }
         end
 
-        def pre_count_truncate_tables(tables, options = {:reset_ids => true})
-          filter = options[:reset_ids] ? method(:has_been_used?) : method(:has_rows?)
-          truncate_tables(tables.select(&filter))
+        def pre_count_truncate_tables(tables)
+          truncate_tables(tables.select { |table| has_been_used?(table) })
         end
 
         private
@@ -158,9 +157,8 @@ module DatabaseCleaner
           execute("TRUNCATE TABLE #{table_names.map{|name| quote_table_name(name)}.join(', ')} #{restart_identity} #{cascade};")
         end
 
-        def pre_count_truncate_tables(tables, options = {:reset_ids => true})
-          filter = options[:reset_ids] ? method(:has_been_used?) : method(:has_rows?)
-          truncate_tables(tables.select(&filter))
+        def pre_count_truncate_tables(tables)
+          truncate_tables(tables.select { |table| has_been_used?(table) })
         end
 
         def database_cleaner_table_cache
@@ -240,7 +238,7 @@ module DatabaseCleaner
         connection = connection_class.connection
         connection.disable_referential_integrity do
           if pre_count? && connection.respond_to?(:pre_count_truncate_tables)
-            connection.pre_count_truncate_tables(tables_to_truncate(connection), {:reset_ids => reset_ids?})
+            connection.pre_count_truncate_tables(tables_to_truncate(connection))
           else
             connection.truncate_tables(tables_to_truncate(connection))
           end
@@ -274,10 +272,6 @@ module DatabaseCleaner
 
       def pre_count?
         @pre_count == true
-      end
-
-      def reset_ids?
-        @reset_ids != false
       end
     end
   end

--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -47,12 +47,6 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
             expect(User.create.id).to eq 1
           end
 
-          xit "should not reset AUTO_INCREMENT index of table if :reset_ids is false" do
-            strategy = described_class.new(reset_ids: false)
-            strategy.clean
-            expect(User.create.id).to eq 3
-          end
-
           it "should truncate all tables except for schema_migrations" do
             strategy.clean
             count = connection.select_value("select count(*) from schema_migrations;").to_i


### PR DESCRIPTION
So, I'm not really clear on whether or not this option ever worked. The test has been disabled for years, and I don't see any code in the adapter itself that would even suggest effecting this preference. Therefore, I think we should delete it while we can! Once this is merged, I'll add deprecation warnings to the v1.99 branch.

An alternative to removing it is to take the time to make this option actually work again. But, it seems of dubious value to me, and since we haven't been seeing any bug reports regarding its disfunction, I think removing it is the right move. If it turns out that someone really wants it back, they can always open a PR, after all!

@etagwerker Any insight into this, having been with the project as long as you have?