### PR TITLE
Be explicit about activerecord support

### DIFF
--- a/database_cleaner-active_record.gemspec
+++ b/database_cleaner-active_record.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "database_cleaner-core", "~>2.0.0.beta2"
-  spec.add_dependency "activerecord"
+  spec.add_dependency "activerecord", ">= 5.a"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "appraisal"


### PR DESCRIPTION
In recent commits, support for `activerecord` versions prior to 5.a (any versions where the major segment is less than 5) was dropped.

However, a minimum required version in the gemspec file was not added. That means, if you're using rails 4.2 for example and you are specifying a requirement for `database_cleaner` that allows prereleases, `bundler` will choose version 2.0.0.beta2 of the `activerecord` adapter because it
thinks its compatible (no requirement is equivalent to "allow every version").

We can fix this by being explicit about the minimum version supported.

See the failing CI in https://github.com/cucumber/cucumber-rails/pull/463 for an example of this issue. Note that since you are still in a "prerelease phase", this is not a common problem because bundler by default does not choose prereleases. However, in this case I specified a requirement of ` 'database_cleaner', '>= 1.8.0.beta'`. That means that since I'm willing to use prereleases, bundler interprets that it is also allowed to pickup prereleases of dependencies of `database_cleaner`, and thus the problem surfaces.