### PR TITLE
Rails 6.1.1 upgrade fixes

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -47,7 +47,8 @@ module DatabaseCleaner
       def load_config
         if self.db != :default && self.db.is_a?(Symbol) && File.file?(DatabaseCleaner::ActiveRecord.config_file_location)
           connection_details = YAML::load(ERB.new(IO.read(DatabaseCleaner::ActiveRecord.config_file_location)).result)
-          @connection_hash   = valid_config(connection_details)[self.db.to_s]
+          @connection_hash   = valid_config(connection_details).configs_for(env_name: self.db.to_s)
+                                                               .first.configuration_hash
         end
       end
 

--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -65,7 +65,9 @@ module DatabaseCleaner
         if ::ActiveRecord::Base.respond_to?(:descendants)
           database_name = connection_hash["database"] || connection_hash[:database]
           models        = ::ActiveRecord::Base.descendants
-          models.select(&:connection_pool).detect { |m| m.connection_pool.spec.config[:database] == database_name }
+          models.select(&:connection_pool).detect do |m|
+            m.connection_pool.pool_config.db_config.configuration_hash[:database] == database_name
+          end
         end
       end
 


### PR DESCRIPTION
Related to https://github.com/DatabaseCleaner/database_cleaner-active_record/issues/48
This PR is not pretending to fix all possible errors in 6.1.1, but it fixed error described in issue
Maybe it will be helpful for somebody with the same situation (fork repo and add this update / using specific branch in this repo)

Unfortunately, this PR has no tests, because of absence of my experience in test writing. Sorry for that.
Also, if this change will be approved it would be great to add this update to database_cleaner v1.8 (as 1.8.6)

Also, there is an update for Rails 6.2.0 (`configs_for` instead of deprecating `[]`) 