### PR TITLE
Add PostGIS adapter.

### DIFF
--- a/database_cleaner-active_record.gemspec
+++ b/database_cleaner-active_record.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "activerecord-postgis-adapter"
 end

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -67,7 +67,7 @@ module DatabaseCleaner
         when "SQLite"
           extend AbstractMysqlAdapter
           extend SQLiteAdapter
-        when "PostgreSQL"
+        when "PostgreSQL", "PostGIS"
           extend AbstractMysqlAdapter
           extend PostgreSQLAdapter
         end

--- a/spec/support/sample.config.yml
+++ b/spec/support/sample.config.yml
@@ -8,7 +8,7 @@ mysql2:
   encoding: utf8
 
 postgres:
-  adapter: postgresql
+  adapter: postgis
   database: database_cleaner_test
   username: postgres
   password:


### PR DESCRIPTION
In the case of the [PostGIS adapter](https://github.com/rgeo/activerecord-postgis-adapter) DatabaseCleaner doesn't do `RESTART IDENTITY CASCADE`. Which can lead to errors in tests if they rely on sequences associated with table columns.