### PR TITLE
Support PostGIS connections

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -67,7 +67,7 @@ module DatabaseCleaner
         when "SQLite"
           extend AbstractMysqlAdapter
           extend SQLiteAdapter
-        when "PostgreSQL"
+        when "PostgreSQL", "PostGIS"
           extend AbstractMysqlAdapter
           extend PostgreSQLAdapter
         end


### PR DESCRIPTION
These work just like PostgreSQL connections, but the adapter_name is different.

Fixes a regression from database-cleaner 1.8.5, where PostGIS was detected as PostgreSQL automatically.