### PR TITLE
Use RESTRICT instead of CASCADE when truncating with postgres

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -189,7 +189,7 @@ module DatabaseCleaner
 
         def truncate_tables(table_names)
           return if table_names.nil? || table_names.empty?
-          execute("TRUNCATE TABLE #{table_names.map{|name| quote_table_name(name)}.join(', ')} RESTART IDENTITY CASCADE;")
+          execute("TRUNCATE TABLE #{table_names.map{|name| quote_table_name(name)}.join(', ')} RESTART IDENTITY RESTRICT;")
         end
 
         def pre_count_truncate_tables(tables)


### PR DESCRIPTION
So the problem was described in this issue https://github.com/DatabaseCleaner/database_cleaner-active_record/issues/57

In case of two tables, from which one was referencing another, when only referenced table was set to be truncated (e.g. with `only` option) then referencing table was silently truncated as well because of how postgres's `TRUNCATE` works with `CASCADE` option:

> Automatically truncate all tables that have foreign-key references to any of the named tables, or to any tables added to the group due to CASCADE.

In case of applications with complex database schema it was easy to stumble upon a problem when such referencing table was truncated despite it was not named to truncate and it was really hard to tell why at the first glance.

With RESTRICT option truncation fails with an exception with clear message about what is the problem and which tables are referencing each another.
