### PR TITLE
CI: Avoid a float 3.0 conversion to "3"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ services:
   - mysql
   - postgresql
 rvm:
-  - 2.5
-  - 2.6
-  - 2.7
-  - 3.0
+  - "2.5"
+  - "2.6"
+  - "2.7"
+  - "3.0"
 gemfile:
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
@@ -14,9 +14,9 @@ gemfile:
   - gemfiles/rails_6.1.gemfile
 jobs:
   exclude: # Unsupported combos: https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
-  - rvm: 3.0
+  - rvm: "3.0"
     gemfiles/rails_5.1.gemfile
-  - rvm: 3.0
+  - rvm: "3.0"
     gemfiles/rails_5.2.gemfile
 
 before_install:


### PR DESCRIPTION
YAML is hard. This change avoids a potential issue, and makes the change to all of the rvm list elements, to encourage readers to keep quoting these.