### PR TITLE
gemspec: Be explicit about no executables

### DIFF
--- a/database_cleaner-active_record.gemspec
+++ b/database_cleaner-active_record.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = []
   spec.require_paths = ["lib"]
 
   spec.add_dependency "database_cleaner-core", "~>2.0.0"


### PR DESCRIPTION
This gem exposes 0 executables, and this change makes that clearer.