### PR TITLE
Fix an issue with same db name for different adapters

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -69,8 +69,10 @@ module DatabaseCleaner
         return unless ::ActiveRecord::Base.respond_to?(:descendants)
 
         database_name = connection_hash['database'] || connection_hash[:database]
+        adapter = connection_hash['adapter'] || connection_hash[:adapter]
         ::ActiveRecord::Base.descendants.select(&:connection_pool).detect do |model|
-          database_for(model) == database_name
+          config = config_for(model)
+          config[:database] == database_name && config[:adapter] == adapter
         end
       end
 
@@ -79,7 +81,7 @@ module DatabaseCleaner
         ::ActiveRecord::Base
       end
 
-      def database_for(model)
+      def config_for(model)
         if model.connection_pool.respond_to?(:db_config) # ActiveRecord >= 6.1
           model.connection_pool.db_config.configuration_hash[:database]
         else


### PR DESCRIPTION
Appreciate this might be a weird setup, but I have the same database name being served by 2 adapters (2 different DB instances). Here is my `database.yml`:

```yaml
development:
  postgresql:
    adapter: postgresql
    encoding: unicode
    database: db_benchmarks
    host: localhost
    user: postgres
    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
    migrations_paths: db/migrations
  clickhouse:
    adapter: clickhouse
    database: db_benchmarks
    migrations_paths: db/migrations
```

Forget for a moment that I still couldn't test if Clickhouse was actually supported, but when I did the following:

```ruby
require 'database_cleaner/active_record'
DatabaseCleaner[:active_record, db: :clickhouse].strategy = :truncation
DatabaseCleaner[:active_record, db: :clickhouse].clean
```

I noticed that the PostgreSQL database was being cleaned instead!
A bit of digging showed that this is an issue with the connection selector:

```ruby
cleaner = DatabaseCleaner[:active_record, db: :clickhouse]
pp cleaner.strategy.connection_class.connection_pool.db_config
# => {:adapter=>"postgresql", :encoding=>"unicode", :database=>"db_benchmarks", :host=>"localhost", :user=>"postgres", :pool=>5, :migrations_paths=>"db/pg_migrations"}
# postgres connection is being selected instead of ClickHouse since the DB name is the same
```

This PR attempt to fix that by adding the `adapter` as a filter as well