### PR TITLE
Add support for aliased database configs

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -46,7 +46,7 @@ module DatabaseCleaner
 
       def load_config
         if db != :default && db.is_a?(Symbol) && File.file?(DatabaseCleaner::ActiveRecord.config_file_location)
-          connection_details = YAML::load(ERB.new(IO.read(DatabaseCleaner::ActiveRecord.config_file_location)).result)
+          connection_details = YAML.safe_load(ERB.new(IO.read(DatabaseCleaner::ActiveRecord.config_file_location)).result, aliases: true)
           @connection_hash   = valid_config(connection_details, db.to_s)
         end
       end

--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -46,7 +46,12 @@ module DatabaseCleaner
 
       def load_config
         if db != :default && db.is_a?(Symbol) && File.file?(DatabaseCleaner::ActiveRecord.config_file_location)
-          connection_details = YAML.safe_load(ERB.new(IO.read(DatabaseCleaner::ActiveRecord.config_file_location)).result, aliases: true)
+          connection_details =
+            if RUBY_VERSION.match?(/\A2\.5/)
+              YAML.safe_load(ERB.new(IO.read(DatabaseCleaner::ActiveRecord.config_file_location)).result, [], [], true)
+            else
+              YAML.safe_load(ERB.new(IO.read(DatabaseCleaner::ActiveRecord.config_file_location)).result, aliases: true)
+            end
           @connection_hash   = valid_config(connection_details, db.to_s)
         end
       end

--- a/spec/database_cleaner/active_record/base_spec.rb
+++ b/spec/database_cleaner/active_record/base_spec.rb
@@ -38,6 +38,23 @@ module DatabaseCleaner
           expect(strategy.connection_hash).to eq({ 'database' => 'one' })
         end
 
+        context 'when the configs are aliased' do
+          let(:other_db) { :other_db }
+          let(:config_location) { 'spec/support/aliased-example.database.yml' }
+
+          it 'loads configs correctly' do
+            strategy.db = my_db
+            expected_hash = { 'database' => 'one',
+                              'encoding' => 'utf8',
+                              'reconnect' => true }
+            expect(strategy.connection_hash).to eq(expected_hash)
+
+            strategy.db = other_db
+            expected_hash.merge!('database' => 'two')
+            expect(strategy.connection_hash).to eq(expected_hash)
+          end
+        end
+
         context 'when ActiveRecord configuration contains a config for the given db' do
           if ::ActiveRecord.version >= Gem::Version.new('6.1')
             context 'ActiveRecord >= 6.1' do

--- a/spec/support/aliased-example.database.yml
+++ b/spec/support/aliased-example.database.yml
@@ -1,0 +1,11 @@
+default: &default
+  encoding: utf8
+  reconnect: true
+
+my_db:
+  <<: *default
+  database: <%= "ONE".downcase %>
+
+other_db:
+  <<: *default
+  database: <%= "TWO".downcase %>


### PR DESCRIPTION
Our `database.yml` looks like the following: 

```yml
default: &default
  adapter: mysql2
  encoding: utf8
  reconnect: false
  somekey: someval

db1:
  <<: *default
  database: <%= ENV['DB_NAME'] %>

db2: 
  <<: *default
  database: db2name
```

When running the test suite, we were facing this issue:

```
Failure/Error:
  DatabaseCleaner[:active_record, db: :db1].
    clean_with(:deletion, except: %w[some_table])
Psych::BadAlias:
  Unknown alias: default
```

After some investigation, we found out that the line throwing the error was [this one](https://github.com/DatabaseCleaner/database_cleaner-active_record/blob/main/lib/database_cleaner/active_record/base.rb#L49).

The changes in this PR fix said issue