### PR TITLE
Fix only/except examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ The truncation and deletion strategies may accept the following options:
 
 ```ruby
 # Only truncate the "users" table.
-DatabaseCleaner[:active_record].strategy = :truncation, only: ["users"]
+DatabaseCleaner[:active_record].strategy = [:truncation, only: ["users"]]
 
 # Delete all tables except the "users" table.
-DatabaseCleaner[:active_record].strategy = :deletion, except: ["users"]
+DatabaseCleaner[:active_record].strategy = [:deletion, except: ["users"]]
 ```
 
 * `:pre_count` - When set to `true` this will check each table for existing rows before truncating or deleting it.  This can speed up test suites when many of the tables are never populated. Defaults to `false`. (Also, see the section on [What strategy is fastest?](#what-strategy-is-fastest))


### PR DESCRIPTION
The current examples don't work. I believe this is the correct syntax based off of database_cleaner's README.