### PR TITLE
use ActiveRecord::Base.connection.schema_migration.table_name instead ActiveRecord::SchemaMigration.table_name for Rails 7.1 more

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -15,7 +15,11 @@ module DatabaseCleaner
 
     class Base < DatabaseCleaner::Strategy
       def self.migration_table_name
-        ::ActiveRecord::SchemaMigration.table_name
+        if Gem::Version.new("6.0.0") <= ::ActiveRecord.version
+          ::ActiveRecord::Base.connection.schema_migration.table_name
+        else
+          ::ActiveRecord::SchemaMigration.table_name
+        end
       end
 
       def self.exclusion_condition(column_name)


### PR DESCRIPTION
fix https://github.com/DatabaseCleaner/database_cleaner/issues/693

In ActiveRecord 7.1, `ActiveRecord::SchemaMigration.table_name` being removed.
As noted [here](https://github.com/rails/rails/pull/45908/files#diff-353f4f101b1bb04938d761b6e29c88e0f147084e9e276854a77ae5d9a9a3b2a8), we will access it with `ActiveRecord::Base.connection.schema_migration.table_name` instead