### PR TITLE
Add support for ruby version 3.1 and psych 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.6
   - 2.7
   - 3.0
+  - 3.1
 gemfile:
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile

--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -46,8 +46,13 @@ module DatabaseCleaner
 
       def load_config
         if db != :default && db.is_a?(Symbol) && File.file?(DatabaseCleaner::ActiveRecord.config_file_location)
-          connection_details = YAML::load(ERB.new(IO.read(DatabaseCleaner::ActiveRecord.config_file_location)).result)
-          @connection_hash   = valid_config(connection_details, db.to_s)
+          erb = ERB.new(IO.read(DatabaseCleaner::ActiveRecord.config_file_location)).result
+          if YAML.respond_to?(:unsafe_load)
+            connection_details = YAML::unsafe_load(erb)
+          else
+            connection_details = YAML::load(erb)
+          end
+          @connection_hash = valid_config(connection_details, db.to_s)
         end
       end
 

--- a/spec/database_cleaner/active_record/base_spec.rb
+++ b/spec/database_cleaner/active_record/base_spec.rb
@@ -105,6 +105,13 @@ module DatabaseCleaner
             expect(strategy.connection_hash).not_to be
           end
         end
+
+        context 'database.yml with YAML inheritance' do
+          it 'should process erb in the config' do
+            strategy.db = :inherited
+            expect(strategy.connection_hash).to include('adapter' => 'sqlite3')
+          end
+        end
       end
 
       describe "connection_class" do

--- a/spec/support/example.database.yml
+++ b/spec/support/example.database.yml
@@ -1,2 +1,9 @@
 my_db:
   database: <%= "ONE".downcase %>
+
+default: &default
+  adapter: sqlite3
+
+inherited:
+  <<: *default
+  database: example.sqlite3


### PR DESCRIPTION
Ruby 3.1 and above ships with Psych 4.0. Psych throws a `Psych::BadAlias: Unknown alias: default` error when it loads a `database.yml` which uses YAML inheritance such as the following:

```yaml
default: &default
  adapter: sqlite3

inherited:
  <<: *default
  database: example.sqlite3
```

We implement the the same pattern as `ActiveSupport::ConfigurationFile` to circumvent this problem: use `YAML.unsafe_load` when it is available.