### PR TITLE
Add a WHERE clause to delete statement

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -23,7 +23,7 @@ module DatabaseCleaner
       end
 
       def delete_table connection, table_name
-        connection.execute("DELETE FROM #{connection.quote_table_name(table_name)}")
+        connection.execute("DELETE FROM #{connection.quote_table_name(table_name)} WHERE 1=1")
       end
 
       def tables_to_truncate(connection)


### PR DESCRIPTION
Spanner (https://github.com/googleapis/ruby-spanner-activerecord) requires a WHERE clause to execute DELETE statements, this change is all that seems to be required for this gem to work with that database type.