### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.1', '3.0', '2.7', '2.6', '2.5']
+        ruby: ['3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
         rails: ['5.1', '5.2', '6.0', '6.1', '7.0']
         exclude:
+          - ruby: '3.2'
+            rails: '5.1'
+          - ruby: '3.2'
+            rails: '5.2'
+          - ruby: '3.2'
+            rails: '6.0'
+          - ruby: '3.2'
+            rails: '6.1'
           - ruby: '3.1'
             rails: '5.1'
           - ruby: '3.1'
@@ -29,7 +37,7 @@ jobs:
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/spec/database_cleaner/active_record/base_spec.rb
+++ b/spec/database_cleaner/active_record/base_spec.rb
@@ -62,7 +62,7 @@ module DatabaseCleaner
                 allow(::ActiveRecord::Base)
                   .to receive(:configurations).and_return(ac_db_configurations_mock)
                 allow(ac_db_configurations_mock)
-                  .to receive(:configs_for).with(name: my_db.to_s).and_return(hash_config_mock)
+                  .to receive(:configs_for).with({ name: my_db.to_s }).and_return(hash_config_mock)
               end
 
               let(:ac_db_configurations_mock) do


### PR DESCRIPTION
Also updated the checkout version action to 3.

To get the specs to pass, it was necessary to add an explicit hash to the `with` to avoid confusion with keyword arguments.

This runs green on my fork.