### PR TITLE
Fix specs to account for trilogy

### DIFF
--- a/spec/support/database_helper.rb
+++ b/spec/support/database_helper.rb
@@ -39,7 +39,26 @@ class DatabaseHelper < DatabaseCleaner::Spec::DatabaseHelper
   end
 
   def load_schema
-    super
+    id_column = case db
+      when :sqlite3
+        "id INTEGER PRIMARY KEY AUTOINCREMENT"
+      when :mysql2, :trilogy
+        "id INTEGER PRIMARY KEY AUTO_INCREMENT"
+      when :postgres
+        "id SERIAL PRIMARY KEY"
+      end
+    connection.execute <<-SQL
+      CREATE TABLE IF NOT EXISTS users (
+        #{id_column},
+        name INTEGER
+      );
+    SQL
+
+    connection.execute <<-SQL
+      CREATE TABLE IF NOT EXISTS agents (
+        name INTEGER
+      );
+    SQL
 
     if db == :postgres
       connection.execute <<-SQL

--- a/spec/support/database_helper.rb
+++ b/spec/support/database_helper.rb
@@ -3,7 +3,9 @@ require 'database_cleaner/spec/database_helper'
 
 class DatabaseHelper < DatabaseCleaner::Spec::DatabaseHelper
   def self.with_all_dbs &block
-    %w[mysql2 sqlite3 postgres trilogy].map(&:to_sym).each do |db|
+    all_dbs = %w[mysql2 sqlite3 postgres]
+    all_dbs << :trilogy if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("7.1.0")
+    all_dbs.map(&:to_sym).each do |db|
       yield new(db)
     end
   end

--- a/spec/support/sample.config.yml
+++ b/spec/support/sample.config.yml
@@ -8,7 +8,7 @@ mysql2:
   encoding: utf8
 
 trilogy:
-  adapter: trilogy 
+  adapter: trilogy
   database: database_cleaner_test
   username: root
   password:

--- a/spec/support/sample.config.yml
+++ b/spec/support/sample.config.yml
@@ -7,6 +7,15 @@ mysql2:
   port: 3306
   encoding: utf8
 
+trilogy:
+  adapter: trilogy 
+  database: database_cleaner_test
+  username: root
+  password:
+  host: 127.0.0.1
+  port: 3306
+  encoding: utf8
+
 postgres:
   adapter: postgresql
   database: database_cleaner_test


### PR DESCRIPTION
This PR gets the specs green w/trilogy.

Key changes are:

1. Adds trilogy to the sample config
2. Restricts testing of trilogy to ActiveRecord 7.1.0 or later
3. Pulls load_schema out of the `database_cleaner` version of DatabaseHelper and adds :trilogy to the appropriate `when` clause.  In theory `database_cleaner` could be updated here instead, but I was confused by the separation and frankly it seemed simpler to pull the whole thing into this gem.

This runs green on my fork.