### PR TITLE
Defer code loading when active record is properly loaded

### DIFF
--- a/lib/database_cleaner-active_record.rb
+++ b/lib/database_cleaner-active_record.rb
@@ -1,1 +1,1 @@
-require "database_cleaner/active_record"
+require "database_cleaner/active_record/railtie"

--- a/lib/database_cleaner/active_record/railtie.rb
+++ b/lib/database_cleaner/active_record/railtie.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DatabaseCleaner::ActiveRecord
+  class Railtie < ::Rails::Railtie
+    initializer "database_cleaner-active_record" do
+      ActiveSupport.on_load(:active_record) do
+        require "database_cleaner/active_record"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is well known issue. We should prefer to load code that reference active record only when it's AR is already loaded.
It can break other gems initializing process like https://github.com/thoughtbot/factory_bot_rails/pull/432

Related:
- https://github.com/rails/rails/issues/46567
- https://github.com/paper-trail-gem/paper_trail/commit/fc6c5f69410f1b79e617610d522dbedfa4f04f7f (inspiration)
- https://github.com/thoughtbot/factory_bot_rails/pull/432

Fix: https://github.com/DatabaseCleaner/database_cleaner-active_record/issues/89