### PR TITLE
Avoid loading ActiveRecord::Base early

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -1,5 +1,4 @@
 require "delegate"
-require 'active_record/base'
 require 'database_cleaner/active_record/base'
 
 module DatabaseCleaner


### PR DESCRIPTION
Doing this cause a slew of problems with Rails loading process, causing some configurations not to be applied, etc.

Fix: #89
Fix: #90
