### PR TITLE
Fix reset_ids test with Trilogy adapter

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -29,7 +29,7 @@ module DatabaseCleaner
 
       def reset_id_sequence connection, table_name
         case connection.adapter_name
-        when 'Mysql2'
+        when 'Mysql2', 'Trilogy'
           connection.execute("ALTER TABLE #{table_name} AUTO_INCREMENT = 1;")
         when 'SQLite'
           connection.execute("delete from sqlite_sequence where name='#{table_name}';")


### PR DESCRIPTION
https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/71 was merged after https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/88, and did not handle Trilogy.