### PR TITLE
[FIX] Typo for deletion strategy

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -7,9 +7,9 @@ module DatabaseCleaner
       def clean
         connection.disable_referential_integrity do
           if pre_count? && connection.respond_to?(:pre_count_tables)
-            delete_tables(connection, connection.pre_count_tables(tables_to_truncate(connection)))
+            delete_tables(connection, connection.pre_count_tables(tables_to_clean(connection)))
           else
-            delete_tables(connection, tables_to_truncate(connection))
+            delete_tables(connection, tables_to_clean(connection))
           end
         end
       end
@@ -40,7 +40,7 @@ module DatabaseCleaner
         end
       end
 
-      def tables_to_truncate(connection)
+      def tables_to_clean(connection)
         if information_schema_exists?(connection)
           @except += connection.database_cleaner_view_cache + migration_storage_names
           (@only.any? ? @only : tables_with_new_rows(connection)) - @except

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -20,9 +20,9 @@ module DatabaseCleaner
       def clean
         connection.disable_referential_integrity do
           if pre_count? && connection.respond_to?(:pre_count_truncate_tables)
-            connection.pre_count_truncate_tables(tables_to_truncate(connection))
+            connection.pre_count_truncate_tables(tables_to_clean(connection))
           else
-            connection.truncate_tables(tables_to_truncate(connection))
+            connection.truncate_tables(tables_to_clean(connection))
           end
         end
       end
@@ -33,7 +33,7 @@ module DatabaseCleaner
         @connection ||= ConnectionWrapper.new(connection_class.connection)
       end
 
-      def tables_to_truncate(connection)
+      def tables_to_clean(connection)
         if @only.none?
           all_tables = cache_tables? ? connection.database_cleaner_table_cache : connection.database_tables
           @only = all_tables.map { |table| table.split(".").last }


### PR DESCRIPTION
### Motivation / Background

Closes: #95 

For deletion strategy there is a typo in the clean method. Instead of `tables_to_truncate` changed it to `tables_to_clean` which is more meaningful in case of deletion strategy.

To maintain consistency and inheritance change the name in the truncation as well from `tables_to_truncate` to `tables_to_clean`.
