### PR TITLE
Refactor

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -7,9 +7,9 @@ module DatabaseCleaner
       def clean
         connection.disable_referential_integrity do
           if pre_count? && connection.respond_to?(:pre_count_tables)
-            delete_tables(connection, connection.pre_count_tables(tables_to_clean(connection)))
+            delete_tables(connection, connection.pre_count_tables(tables_to_truncate))
           else
-            delete_tables(connection, tables_to_clean(connection))
+            delete_tables(connection, tables_to_truncate)
           end
         end
       end
@@ -40,7 +40,7 @@ module DatabaseCleaner
         end
       end
 
-      def tables_to_clean(connection)
+      def tables_to_truncate
         if information_schema_exists?(connection)
           @except += connection.database_cleaner_view_cache + migration_storage_names
           (@only.any? ? @only : tables_with_new_rows(connection)) - @except

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -20,9 +20,9 @@ module DatabaseCleaner
       def clean
         connection.disable_referential_integrity do
           if pre_count? && connection.respond_to?(:pre_count_truncate_tables)
-            connection.pre_count_truncate_tables(tables_to_clean(connection))
+            connection.pre_count_truncate_tables(tables_to_truncate)
           else
-            connection.truncate_tables(tables_to_clean(connection))
+            connection.truncate_tables(tables_to_truncate)
           end
         end
       end
@@ -39,7 +39,7 @@ module DatabaseCleaner
         )
       end
 
-      def tables_to_clean(connection)
+      def tables_to_truncate
         if @only.none?
           all_tables = cache_tables? ? connection.database_cleaner_table_cache : connection.database_tables
           @only = all_tables.map { |table| table.split(".").last }

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -36,16 +36,12 @@ module DatabaseCleaner
       end
 
       def tables_to_truncate
-        if @only.none?
-          all_tables = cache_tables? ? connection.database_cleaner_table_cache : connection.database_tables
-          @only = all_tables.map { |table| table.split(".").last }
-        end
         @except += connection.database_cleaner_view_cache + migration_storage_names
 
         if pre_count? && connection.respond_to?(:pre_count_tables)
-          connection.pre_count_tables(@only - @except)
+          connection.pre_count_tables(only - @except)
         else
-          @only - @except
+          only - @except
         end
       end
 
@@ -62,6 +58,14 @@ module DatabaseCleaner
 
       def pre_count?
         @pre_count == true
+      end
+
+      def only
+        if @only.none?
+          all_tables = cache_tables? ? connection.database_cleaner_table_cache : connection.database_tables
+          @only = all_tables.map { |table| table.split(".").last }
+        end
+        @only
       end
     end
 


### PR DESCRIPTION
I want to be able to display progress of truncation using ruby-progressbar.

I don't consider the progress bar itself to be a concern of this gem, so all I've done in this PR is some refactoring that was anyway reasonable and that makes it possible to do the following in my application code:

```
cleaner = DatabaseCleaner.cleaners.values.first
cleaner.strategy = [:truncation, { pre_count: true }]
tables_to_truncate = cleaner.strategy.send(:tables_to_truncate)
progress = ProgressBar.create(total: tables_to_truncate.size)
tables = tables_to_truncate

tables.each do |table|
  progress.log "Truncating #{table}"
  cleaner.strategy = [:truncation, { pre_count: true, only: [table]}]
  cleaner.strategy.clean
  progress.increment
end
```

I acknowledge the application code isn't very pretty, but the alternative is exposing the strategies directly, and some small refactoring to support some ugly application code is more likely to be accepted that a major refactor that break encapsulation of the strategies.