### PR TITLE
Avoid accidental replacement of main DB model connections

### DIFF
--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -84,8 +84,11 @@ module DatabaseCleaner
       end
 
       def establish_connection
-        ::ActiveRecord::Base.establish_connection(connection_hash)
-        ::ActiveRecord::Base
+        # creates a temporary ActiveRecord class that is unique to connection_hash
+        ActiveRecord.module_eval("class Temp#{connection_hash.hash.abs} < ::ActiveRecord::Base; self; end")
+          .tap { |ar_class|
+            ar_class.establish_connection(connection_hash)
+          }
       end
 
       def database_for(model)

--- a/spec/database_cleaner/active_record/base_spec.rb
+++ b/spec/database_cleaner/active_record/base_spec.rb
@@ -166,7 +166,8 @@ module DatabaseCleaner
 
             it "establishes a connection with it" do
               expect(::ActiveRecord::Base).to receive(:establish_connection).with(hash)
-              expect(strategy.connection_class).to eq ::ActiveRecord::Base
+              expect(strategy.connection_class).to be < ::ActiveRecord::Base
+              expect(strategy.connection_class.name).to match /^DatabaseCleaner::ActiveRecord::Temp\d+$/
             end
           end
 


### PR DESCRIPTION
fixes #97

### Notes on CI failures

Tests for Rails 7.1 does not pass even at [commit aafa5b2](https://github.com/DatabaseCleaner/database_cleaner-active_record/actions/runs/6972687842/job/18975333189)
