### PR TITLE
Address deprecation of `ActiveRecord::Base.connection` in Rails 7.2

### DIFF
--- a/lib/database_cleaner/active_record/transaction.rb
+++ b/lib/database_cleaner/active_record/transaction.rb
@@ -4,10 +4,16 @@ module DatabaseCleaner
   module ActiveRecord
     class Transaction < Base
       def start
-        # Hack to make sure that the connection is properly set up before cleaning
-        connection_class.connection.transaction {}
+        connection = if ::ActiveRecord.version >= Gem::Version.new("7.2")
+          connection_class.lease_connection
+        else
+          connection_class.connection
+        end
 
-        connection_class.connection.begin_transaction joinable: false
+        # Hack to make sure that the connection is properly set up before cleaning
+        connection.transaction {}
+
+        connection.begin_transaction joinable: false
       end
 
 

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -30,7 +30,13 @@ module DatabaseCleaner
       private
 
       def connection
-        @connection ||= ConnectionWrapper.new(connection_class.connection)
+        @connection ||= ConnectionWrapper.new(
+          if ::ActiveRecord.version >= Gem::Version.new("7.2")
+            connection_class.lease_connection
+          else
+            connection_class.connection
+          end
+        )
       end
 
       def tables_to_truncate(connection)
@@ -246,4 +252,3 @@ module DatabaseCleaner
     private_constant :ConnectionWrapper
   end
 end
-


### PR DESCRIPTION
Context: https://github.com/rails/rails/pull/51349

~Ensures that applications using `config.active_record.permanent_connection_checkout = :disallowed` are supported from Rails 7.2 onwards.~ This was what this PR started as, but this would require a significant API change looking at how the `#start` and `#clean` APIs are used.

Addresses the deprecation of `ActiveRecord::Base.connection` in favour of `ActiveRecord::Base.lease_connection` as of Rails 7.2.

There's one more usage of `.connection` but that seems to be getting removed in #101.