### PR TITLE
For PG truncate, fetch last_value from sequence

### DIFF
--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -218,7 +218,7 @@ module DatabaseCleaner
         def has_been_used?(table)
           return has_rows?(table) unless has_sequence?(table)
 
-          cur_val = select_value("SELECT currval('#{table}_id_seq');").to_i rescue 0
+          cur_val = select_value("SELECT last_value from #{table}_id_seq;").to_i
           cur_val > 0
         end
 


### PR DESCRIPTION
With HEAD, receiving `ERROR:  currval of sequence ...` given currval isn't defined until nextval is invoked 'per session'.
https://www.postgresql.org/docs/current/functions-sequence.html

Therefore looking up what's been persisted whether it was atomically incremented via nextval or manual shifted by something else.