### PR TITLE
Fix CI and Rails 7.1 compatibility on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,44 +4,94 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: 'Ruby: ${{ matrix.ruby }}, Rails: ${{ matrix.rails }}'
+    name: 'Ruby: ${{ matrix.ruby }}, Rails: ${{ matrix.rails }}, Channel: ${{ matrix.channel }}'
     runs-on: 'ubuntu-22.04'
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
-        rails: ['5.1', '5.2', '6.0', '6.1', '7.0', '7.1']
+        ruby: ['3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
+        rails: ['5.1', '5.2', '6.0', '6.1', '7.0', '7.1', '7.2']
+        channel: ['stable']
+
+        include:
+          - ruby: 'ruby-head'
+            rails: 'edge'
+            channel: 'experimental'
+          - ruby: 'ruby-head'
+            rails: '7.2'
+            channel: 'experimental'
+          - ruby: 'ruby-head'
+            rails: '7.1'
+            channel: 'experimental'
+
+          - ruby: '3.3'
+            rails: 'edge'
+            channel: 'experimental'
+          - ruby: '3.2'
+            rails: 'edge'
+            channel: 'experimental'
+          - ruby: '3.1'
+            rails: 'edge'
+            channel: 'experimental'
+
         exclude:
-          - ruby: '3.2'
-            rails: '5.1'
-          - ruby: '3.2'
-            rails: '5.2'
-          - ruby: '3.2'
+          - ruby: '3.3'
+            rails: '7.0' # TODO: works on 7-0-stable branch, remove after a 7.0.x patch release
+          - ruby: '3.3'
+            rails: '6.1'
+          - ruby: '3.3'
             rails: '6.0'
+          - ruby: '3.3'
+            rails: '5.2'
+          - ruby: '3.3'
+            rails: '5.1'
+
           - ruby: '3.2'
             rails: '6.1'
-          - ruby: '3.1'
-            rails: '5.1'
-          - ruby: '3.1'
+          - ruby: '3.2'
+            rails: '6.0'
+          - ruby: '3.2'
             rails: '5.2'
+          - ruby: '3.2'
+            rails: '5.1'
+
           - ruby: '3.1'
             rails: '6.0'
-          - ruby: '3.0'
+          - ruby: '3.1'
+            rails: '5.2'
+          - ruby: '3.1'
             rails: '5.1'
+
+          - ruby: '3.0'
+            rails: '7.2'
           - ruby: '3.0'
             rails: '5.2'
+          - ruby: '3.0'
+            rails: '5.1'
+
+          - ruby: '2.7'
+            rails: '7.2'
+
           - ruby: '2.6'
-            rails: '7.0'
-          - ruby: '2.5'
-            rails: '7.0'
-          - ruby: '2.5'
+            rails: '7.2'
+          - ruby: '2.6'
             rails: '7.1'
           - ruby: '2.6'
+            rails: '7.0'
+
+          - ruby: '2.5'
+            rails: '7.2'
+          - ruby: '2.5'
             rails: '7.1'
+          - ruby: '2.5'
+            rails: '7.0'
+
+    continue-on-error: ${{ matrix.channel != 'stable' }}
+
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/Appraisals
+++ b/Appraisals
@@ -8,16 +8,28 @@ end
 
 appraise "rails-6.0" do
   gem "rails", "~> 6.0.0"
+  gem "sqlite3", "~> 1.5"
 end
 
 appraise "rails-6.1" do
   gem "rails", "~> 6.1.0"
+  gem "sqlite3", "~> 1.5"
 end
 
 appraise "rails-7.0" do
   gem "rails", "~> 7.0.0"
+  gem "sqlite3", "~> 1.7"
 end
 
 appraise "rails-7.1" do
   gem "rails", "~> 7.1.0"
+  gem "sqlite3", "~> 1.7" # FIXME: remove after rails/rails#51592
+end
+
+appraise "rails-7.2" do
+  gem "rails", "~> 7.2.0.beta2"
+end
+
+appraise "rails-edge" do
+  gem "rails", github: "rails/rails"
 end

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -4,17 +4,11 @@ source "https://rubygems.org"
 
 gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_cleaner"
 gem "rails", "~> 6.1.0"
+gem "sqlite3", "~> 1.5"
 
 group :test do
   gem "simplecov", require: false
   gem "codecov", require: false
 end
-
-if RUBY_VERSION >= '3.1'
-  gem 'net-smtp', require: false
-  gem 'net-imap', require: false
-  gem 'net-pop', require: false
-end
-
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_cleaner"
 gem "rails", "~> 7.0.0"
+gem "sqlite3", "~> 1.7"
 
 group :test do
   gem "simplecov", require: false

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -3,7 +3,8 @@
 source "https://rubygems.org"
 
 gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_cleaner"
-gem "rails", github: 'rails/rails' # "~> 7.1.0"
+gem "rails", "~> 7.1.0"
+gem "sqlite3", "~> 1.7"
 
 group :test do
   gem "simplecov", require: false

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -3,8 +3,7 @@
 source "https://rubygems.org"
 
 gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_cleaner"
-gem "rails", "~> 6.0.0"
-gem "sqlite3", "~> 1.5"
+gem "rails", "~> 7.2.0.beta2"
 
 group :test do
   gem "simplecov", require: false

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -3,8 +3,7 @@
 source "https://rubygems.org"
 
 gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_cleaner"
-gem "rails", "~> 6.0.0"
-gem "sqlite3", "~> 1.5"
+gem "rails", github: "rails/rails"
 
 group :test do
   gem "simplecov", require: false

--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -15,9 +15,9 @@ module DatabaseCleaner
 
     class Base < DatabaseCleaner::Strategy
       def self.migration_table_name
-        if Gem::Version.new("7.1.0") < ::ActiveRecord.version
+        if ::ActiveRecord.version >= Gem::Version.new("7.2.0.alpha")
           ::ActiveRecord::Base.connection_pool.schema_migration.table_name
-        elsif Gem::Version.new("6.0.0") <= ::ActiveRecord.version
+        elsif ::ActiveRecord.version >= Gem::Version.new("6.0.0.alpha")
           ::ActiveRecord::Base.connection.schema_migration.table_name
         else
           ::ActiveRecord::SchemaMigration.table_name

--- a/lib/database_cleaner/active_record/base.rb
+++ b/lib/database_cleaner/active_record/base.rb
@@ -15,9 +15,9 @@ module DatabaseCleaner
 
     class Base < DatabaseCleaner::Strategy
       def self.migration_table_name
-        if ::ActiveRecord.version >= Gem::Version.new("7.2.0.alpha")
+        if ::ActiveRecord::Base.connection_pool.respond_to?(:schema_migration) # Rails >= 7.2
           ::ActiveRecord::Base.connection_pool.schema_migration.table_name
-        elsif ::ActiveRecord.version >= Gem::Version.new("6.0.0.alpha")
+        elsif ::ActiveRecord::Base.connection.respond_to?(:schema_migration) # Rails >= 6.0
           ::ActiveRecord::Base.connection.schema_migration.table_name
         else
           ::ActiveRecord::SchemaMigration.table_name


### PR DESCRIPTION
Improve CI

Stable builds:
- Test against Ruby 3.3 stable
- Test against Rails 7.1 stable
- Test against Rails 7.2 beta

Experimental builds:
- Test against Rails edge (previously: 7.1, ref: #106)
- Test against Ruby head

Fixes:
- Fix sqlite3 dependency on old Rails versions

Updates:
- Update GitHub actions

Readability:
- Sort and group inclusion and exclusions in CI matrix

---

Fix Rails 7.1 compatibility

Also:
- Invert the logic to make the conditional more readable
- Add "alpha" to version to include pre-releases

ActiveRecord:
- 7.2: `Base.connection_pool.schema_migration.table_name`
- 7.1, 7.0, 6.x: `Base.connection.schema_migration.table_name`
- 5.x: `SchemaMigration.table_name`

---

Use `respond_to?` to determine the schema migration table name

Close #106