### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/database_cleaner-active_record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Development (unreleased)
 
+* Provide a 'Changelog' link on Rubygems: https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/114
+
 ## v2.2.1 2025-05-13
 
 * https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/111 by @tagliala

--- a/database_cleaner-active_record.gemspec
+++ b/database_cleaner-active_record.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "trilogy"
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/blob/main/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/database_cleaner-active_record which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/