### PR TITLE
release_connection after cleaning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3', '3.2', '3.1']
-        rails: ['6.1', '7.0', '7.1', '7.2']
+        ruby: ['3.4', '3.3', '3.2', '3.1']
+        rails: ['6.1', '7.0', '7.1', '7.2', '8.0']
         channel: ['stable']
 
         include:
           - ruby: 'ruby-head'
             rails: 'edge'
+            channel: 'experimental'
+          - ruby: 'ruby-head'
+            rails: '8.0'
             channel: 'experimental'
           - ruby: 'ruby-head'
             rails: '7.2'
@@ -24,24 +27,28 @@ jobs:
             rails: '7.1'
             channel: 'experimental'
 
+          - ruby: '3.4'
+            rails: 'edge'
+            channel: 'experimental'
           - ruby: '3.3'
             rails: 'edge'
             channel: 'experimental'
           - ruby: '3.2'
-            rails: 'edge'
-            channel: 'experimental'
-          - ruby: '3.1'
             rails: 'edge'
             channel: 'experimental'
 
         exclude:
-          - ruby: '3.3'
-            rails: '7.0' # TODO: works on 7-0-stable branch, remove after a 7.0.x patch release
+          - ruby: '3.4'
+            rails: '6.1'
+
           - ruby: '3.3'
             rails: '6.1'
 
           - ruby: '3.2'
             rails: '6.1'
+
+          - ruby: '3.1'
+            rails: '8.0'
 
     continue-on-error: ${{ matrix.channel != 'stable' }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Development (unreleased)
 
+* Release database connections after cleaning: https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/122
 * Provide a 'Changelog' link on Rubygems: https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/114
 * Fix bundling and CONTRIBUTE.md instructions: https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/123
 * Fix order of arguments in `truncate_tables` expectation https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/124

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -6,6 +6,9 @@ gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_c
 gem "rails", "~> 6.1.0"
 gem "sqlite3", "~> 1.5"
 gem "concurrent-ruby", "1.3.4"
+gem "logger"
+gem "mutex_m"
+gem "bigdecimal"
 
 group :test do
   gem "simplecov", require: false

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -6,6 +6,9 @@ gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_c
 gem "rails", "~> 7.0.0"
 gem "sqlite3", "~> 1.7"
 gem "concurrent-ruby", "1.3.4"
+gem "logger"
+gem "mutex_m"
+gem "bigdecimal"
 
 group :test do
   gem "simplecov", require: false

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -5,6 +5,9 @@ source "https://rubygems.org"
 gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_cleaner"
 gem "rails", "~> 7.1.0"
 gem "sqlite3", "~> 1.7"
+gem "logger"
+gem "mutex_m"
+gem "bigdecimal"
 
 group :test do
   gem "simplecov", require: false

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_cleaner"
-gem "rails", "~> 7.2.0"
+gem "rails", "~> 8.0"
 gem "logger"
 gem "mutex_m"
 gem "bigdecimal"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -4,6 +4,9 @@ source "https://rubygems.org"
 
 gem "database_cleaner-core", git: "https://github.com/DatabaseCleaner/database_cleaner"
 gem "rails", github: "rails/rails"
+gem "logger"
+gem "mutex_m"
+gem "bigdecimal"
 
 group :test do
   gem "simplecov", require: false

--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -9,6 +9,8 @@ module DatabaseCleaner
             delete_tables(connection, tables_to_clean(connection))
           end
         end
+
+        connection_class.connection_pool.release_connection
       end
 
       private

--- a/lib/database_cleaner/active_record/transaction.rb
+++ b/lib/database_cleaner/active_record/transaction.rb
@@ -22,6 +22,8 @@ module DatabaseCleaner
             connection.rollback_transaction
           end
         end
+
+        connection_class.connection_pool.release_connection
       end
     end
   end

--- a/lib/database_cleaner/active_record/truncation.rb
+++ b/lib/database_cleaner/active_record/truncation.rb
@@ -26,6 +26,8 @@ module DatabaseCleaner
             connection.truncate_tables(tables_to_clean(connection), { truncate_option: @truncate_option })
           end
         end
+
+        connection_class.connection_pool.release_connection
       end
 
       private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require "bundler/setup"
 
+require "logger" # Fix for Rails 7.0 tests
+
 if ENV['COVERAGE'] == 'true'
   require "simplecov"
 


### PR DESCRIPTION
For Rails >= 7.2, this library gets a connection via `#lease_connection`. But it never releases the connection. Release the connection back to the pool after `#clean`-ing.

Rails >= 7.2 does connection health checks / reconnect on connection checkout. If the connection is never checked back into the pool, it will never get "repaired", which makes testing database connection issues tricky.