### PR TITLE
[Fix] Expect truncated tables in any order, and handle postgres extra table

### DIFF
--- a/spec/database_cleaner/active_record/truncation_spec.rb
+++ b/spec/database_cleaner/active_record/truncation_spec.rb
@@ -106,7 +106,10 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
           it "specifies cascade when truncating" do
             User.create!({name: 1})
 
-            expect(strategy.send(:connection)).to receive(:truncate_tables).with(['users', 'agents'], {truncate_option: :cascade})
+            tables_to_truncate = ["agents", "users"]
+            tables_to_truncate << "user_profiles" if helper.db == :postgres
+
+            expect(strategy.send(:connection)).to receive(:truncate_tables).with(array_including(tables_to_truncate), {truncate_option: :cascade})
             strategy.clean
           end
         end
@@ -117,7 +120,10 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Truncation do
           it "specifies restrict when truncating" do
             User.create!
 
-            expect(strategy.send(:connection)).to receive(:truncate_tables).with(['users', 'agents'], {truncate_option: :restrict})
+            tables_to_truncate = ["agents", "users"]
+            tables_to_truncate << "user_profiles" if helper.db == :postgres
+
+            expect(strategy.send(:connection)).to receive(:truncate_tables).with(array_including(tables_to_truncate), {truncate_option: :restrict})
             strategy.clean
           end
         end


### PR DESCRIPTION
This PR fixes 2 issues with the specs:

- the `truncate_tables` methods can receive the names of the tables in different order (depending on the DB engine and DB version), so it's better to use `array_including(...)` since the order is not really important
- the code was not handling postgres having one more table (`user_profiles`)