### PR TITLE
Add PostgreSQL support for tables_with_new_rows optimization

### DIFF
--- a/lib/database_cleaner/active_record/deletion.rb
+++ b/lib/database_cleaner/active_record/deletion.rb
@@ -64,6 +64,17 @@ module DatabaseCleaner
       end
 
       def build_table_stats_query(connection)
+        case connection.adapter_name
+        when "Mysql2", "Trilogy"
+          build_mysql_table_stats_query(connection)
+        when "PostgreSQL"
+          build_postgresql_table_stats_query(connection)
+        else
+          ''
+        end
+      end
+
+      def build_mysql_table_stats_query(connection)
         tables = connection.select_values(<<-SQL)
           SELECT table_name
           FROM information_schema.tables
@@ -76,8 +87,22 @@ module DatabaseCleaner
         queries.join(' UNION ALL ')
       end
 
+      def build_postgresql_table_stats_query(connection)
+        tables = connection.select_values(<<-SQL)
+          SELECT table_name
+          FROM information_schema.tables
+          WHERE table_schema = current_schema()
+          AND table_type = 'BASE TABLE'
+          AND #{self.class.exclusion_condition('table_name')};
+        SQL
+        queries = tables.map do |table|
+          "(SELECT #{connection.quote(table)} FROM #{connection.quote_table_name(table)} LIMIT 1)"
+        end
+        queries.join(' UNION ALL ')
+      end
+
       def information_schema_exists? connection
-        ["Mysql2", "Trilogy"].include?(connection.adapter_name)
+        ["Mysql2", "Trilogy", "PostgreSQL"].include?(connection.adapter_name)
       end
     end
   end

--- a/spec/database_cleaner/active_record/deletion_spec.rb
+++ b/spec/database_cleaner/active_record/deletion_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Deletion do
           subject(:strategy) { described_class.new(cache_tables: true) }
 
           it 'caches the list of tables to be deleted from' do
-            if [:mysql2, :trilogy].include?(helper.db)
+            if [:mysql2, :trilogy, :postgres].include?(helper.db)
               expect(strategy).to receive(:build_table_stats_query).once.and_return("")
             elsif helper.db == :postgres
               expect(strategy.send(:connection)).to receive(:tables_with_schema).once.and_return([])
@@ -116,7 +116,7 @@ RSpec.describe DatabaseCleaner::ActiveRecord::Deletion do
           subject(:strategy) { described_class.new(cache_tables: false) }
 
           it 'does not cache the list of tables to be deleted from' do
-            if [:mysql2, :trilogy].include?(helper.db)
+            if [:mysql2, :trilogy, :postgres].include?(helper.db)
               expect(strategy).to receive(:build_table_stats_query).twice.and_return("")
             elsif helper.db == :postgres
               expect(strategy.send(:connection)).to receive(:tables_with_schema).twice.and_return([])


### PR DESCRIPTION
Extends the `tables_with_new_rows` method to work with PostgreSQL. Previously, this optimization only worked for MySQL/Trilogy adapters.